### PR TITLE
Implement FileReaderStrategy

### DIFF
--- a/Quizlet.Tests/FileServiceTests.cs
+++ b/Quizlet.Tests/FileServiceTests.cs
@@ -1,15 +1,35 @@
 ﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using Microsoft.Extensions.DependencyInjection;
 using PdfSharp.Drawing;
 using PdfSharp.Pdf;
+using Quizlet.Interfaces;
+using Quizlet.Readers;
 using Quizlet.Services;
 
 namespace Quizlet.Tests;
 
 public class FileServiceTests
 {
-    private readonly FileService _fileService = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly FileService _fileService;
+
+    public FileServiceTests()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        // Registrierung der Strategien
+        serviceCollection.AddTransient<IFileReaderStrategy, TxtFileReader>();
+        serviceCollection.AddTransient<IFileReaderStrategy, PdfFileReader>();
+        serviceCollection.AddTransient<IFileReaderStrategy, DocxFileReader>();
+
+        // Registrierung des FileService
+        serviceCollection.AddTransient<FileService>();
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+        _fileService = _serviceProvider.GetRequiredService<FileService>();
+    }
 
     [Fact]
     public async Task ReadFileContentAsync_ShouldThrowArgumentException_WhenFilePathIsNullOrEmpty()

--- a/Quizlet.Tests/FileServiceTests.cs
+++ b/Quizlet.Tests/FileServiceTests.cs
@@ -32,33 +32,33 @@ public class FileServiceTests
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldThrowArgumentException_WhenFilePathIsNullOrEmpty()
+    public void ReadFileContent_ShouldThrowArgumentException_WhenFilePathIsNullOrEmpty()
     {
         // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(() => _fileService.ReadFileContentAsync(null));
-        await Assert.ThrowsAsync<ArgumentException>(() => _fileService.ReadFileContentAsync(string.Empty));
+        Assert.Throws<ArgumentException>(() => _fileService.ReadFileContent(null));
+        Assert.Throws<ArgumentException>(() => _fileService.ReadFileContent(string.Empty));
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldThrowFileNotFoundException_WhenFileDoesNotExist()
+    public void ReadFileContent_ShouldThrowFileNotFoundException_WhenFileDoesNotExist()
     {
         // Arrange
         var nonExistentFilePath = "nonexistentfile.txt";
 
         // Act & Assert
-        await Assert.ThrowsAsync<FileNotFoundException>(() => _fileService.ReadFileContentAsync(nonExistentFilePath));
+        Assert.Throws<FileNotFoundException>(() => _fileService.ReadFileContent(nonExistentFilePath));
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldReturnContent_ForTxtFile()
+    public void ReadFileContent_ShouldReturnContent_ForTxtFile()
     {
         // Arrange
         var filePath = "testfile.txt";
         var expectedContent = "Dies ist ein Testinhalt.";
-        await File.WriteAllTextAsync(filePath, expectedContent);
+        File.WriteAllText(filePath, expectedContent);
 
         // Act
-        var content = await _fileService.ReadFileContentAsync(filePath);
+        var content = _fileService.ReadFileContent(filePath);
 
         // Assert
         Assert.Equal(expectedContent, content);
@@ -68,7 +68,7 @@ public class FileServiceTests
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldReturnContent_ForDocxFile()
+    public void ReadFileContent_ShouldReturnContent_ForDocxFile()
     {
         // Arrange
         var filePath = "testfile.docx";
@@ -76,7 +76,7 @@ public class FileServiceTests
         CreateDocxFile(filePath, expectedContent);
 
         // Act
-        var content = await _fileService.ReadFileContentAsync(filePath);
+        var content = _fileService.ReadFileContent(filePath);
 
         // Assert
         Assert.Equal(expectedContent, content);
@@ -85,9 +85,8 @@ public class FileServiceTests
         File.Delete(filePath);
     }
 
-
     [Fact]
-    public async Task ReadFileContentAsync_ShouldReturnContent_ForPdfFile()
+    public void ReadFileContent_ShouldReturnContent_ForPdfFile()
     {
         // Arrange
         var filePath = "testfile.pdf";
@@ -95,7 +94,7 @@ public class FileServiceTests
         CreatePdfFile(filePath, expectedContent);
 
         // Act
-        var content = await _fileService.ReadFileContentAsync(filePath);
+        var content = _fileService.ReadFileContent(filePath);
 
         // Assert
         Assert.Equal(expectedContent, content);
@@ -105,33 +104,32 @@ public class FileServiceTests
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldThrowNotSupportedException_WhenFileTypeIsNotSupported()
+    public void ReadFileContent_ShouldThrowNotSupportedException_WhenFileTypeIsNotSupported()
     {
         // Arrange
         var filePath = "testfile.invalidfileformat";
-        await File.WriteAllTextAsync(filePath, "Test content");
+        File.WriteAllText(filePath, "Test content");
 
         // Act & Assert
-        await Assert.ThrowsAsync<NotSupportedException>(() => _fileService.ReadFileContentAsync(filePath));
+        Assert.Throws<NotSupportedException>(() => _fileService.ReadFileContent(filePath));
 
         // Cleanup
         File.Delete(filePath);
     }
 
     [Fact]
-    public async Task ReadFileContentAsync_ShouldThrowInvalidOperationException_WhenDocxFileStructureIsInvalid()
+    public void ReadFileContent_ShouldThrowInvalidOperationException_WhenDocxFileStructureIsInvalid()
     {
         // Arrange
         var filePath = "invalidfile.docx";
         CreateDocxFileWithInvalidStructure(filePath);
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _fileService.ReadFileContentAsync(filePath));
+        Assert.Throws<InvalidOperationException>(() => _fileService.ReadFileContent(filePath));
 
         // Cleanup
         File.Delete(filePath);
     }
-
 
     private static void CreateDocxFile(string filePath, string content)
     {

--- a/Quizlet.Tests/Quizlet.Tests.csproj
+++ b/Quizlet.Tests/Quizlet.Tests.csproj
@@ -8,21 +8,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="FluentAssertions" Version="8.1.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="PdfSharp" Version="6.1.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="FluentAssertions" Version="8.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="PdfSharp" Version="6.1.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Quizlet\Quizlet.csproj"/>
+        <ProjectReference Include="..\Quizlet\Quizlet.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Quizlet/Controllers/FileController.cs
+++ b/Quizlet/Controllers/FileController.cs
@@ -36,7 +36,7 @@ public class FileController(IFileService fileService) : ControllerBase
                 await formFile.CopyToAsync(stream);
             }
 
-            var content = await fileService.ReadFileContentAsync(tempFilePath);
+            var content = fileService.ReadFileContent(tempFilePath);
 
             return Ok(new { content });
         }

--- a/Quizlet/Interfaces/IFileReaderStrategy.cs
+++ b/Quizlet/Interfaces/IFileReaderStrategy.cs
@@ -3,6 +3,6 @@
     public interface IFileReaderStrategy
     {
         bool CanHandle(string fileExtension);
-        Task<string> ReadFileContentAsync(string filePath);
+        string ReadFileContent(string filePath);
     }
 }

--- a/Quizlet/Interfaces/IFileReaderStrategy.cs
+++ b/Quizlet/Interfaces/IFileReaderStrategy.cs
@@ -1,0 +1,8 @@
+﻿namespace Quizlet.Interfaces
+{
+    public interface IFileReaderStrategy
+    {
+        bool CanHandle(string fileExtension);
+        Task<string> ReadFileContentAsync(string filePath);
+    }
+}

--- a/Quizlet/Interfaces/IFileService.cs
+++ b/Quizlet/Interfaces/IFileService.cs
@@ -2,5 +2,5 @@ namespace Quizlet.Interfaces;
 
 public interface IFileService
 {
-    Task<string> ReadFileContentAsync(string filePath);
+    string ReadFileContent(string filePath);
 }

--- a/Quizlet/Program.cs
+++ b/Quizlet/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.OpenApi.Models;
 using Quizlet.Interfaces;
+using Quizlet.Readers;
 using Quizlet.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,6 +18,11 @@ builder.Services.AddHealthChecks();
 
 // Register Services
 builder.Services.AddScoped<IFileService, FileService>();
+
+// Register Readers
+builder.Services.AddTransient<IFileReaderStrategy, TxtFileReader>();
+builder.Services.AddTransient<IFileReaderStrategy, PdfFileReader>();
+builder.Services.AddTransient<IFileReaderStrategy, DocxFileReader>();
 
 var app = builder.Build();
 

--- a/Quizlet/Quizlet.csproj
+++ b/Quizlet/Quizlet.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0"/>
-        <PackageReference Include="PdfPig" Version="0.1.10"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4"/>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+        <PackageReference Include="PdfPig" Version="0.1.10" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
     </ItemGroup>
 
 </Project>

--- a/Quizlet/Readers/DocxFileReader.cs
+++ b/Quizlet/Readers/DocxFileReader.cs
@@ -8,7 +8,7 @@ namespace Quizlet.Readers
     {
         public bool CanHandle(string fileExtension) => fileExtension.Equals(".docx", StringComparison.OrdinalIgnoreCase);
 
-        public async Task<string> ReadFileContentAsync(string filePath)
+        public string ReadFileContent(string filePath)
         {
             using var doc = WordprocessingDocument.Open(filePath, false);
             if (doc.MainDocumentPart?.Document?.Body == null)
@@ -17,7 +17,7 @@ namespace Quizlet.Readers
             var content = string.Join(Environment.NewLine, doc.MainDocumentPart.Document.Body.Elements<Paragraph>()
                 .Select(p => p.InnerText));
 
-            return await Task.FromResult(content);
+            return content;
         }
     }
 }

--- a/Quizlet/Readers/DocxFileReader.cs
+++ b/Quizlet/Readers/DocxFileReader.cs
@@ -1,0 +1,23 @@
+﻿using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Quizlet.Interfaces;
+
+namespace Quizlet.Readers
+{
+    public class DocxFileReader : IFileReaderStrategy
+    {
+        public bool CanHandle(string fileExtension) => fileExtension.Equals(".docx", StringComparison.OrdinalIgnoreCase);
+
+        public async Task<string> ReadFileContentAsync(string filePath)
+        {
+            using var doc = WordprocessingDocument.Open(filePath, false);
+            if (doc.MainDocumentPart?.Document?.Body == null)
+                throw new InvalidOperationException("The document structure is invalid or missing.");
+
+            var content = string.Join(Environment.NewLine, doc.MainDocumentPart.Document.Body.Elements<Paragraph>()
+                .Select(p => p.InnerText));
+
+            return await Task.FromResult(content);
+        }
+    }
+}

--- a/Quizlet/Readers/PdfFileReader.cs
+++ b/Quizlet/Readers/PdfFileReader.cs
@@ -8,7 +8,7 @@ namespace Quizlet.Readers
     {
         public bool CanHandle(string fileExtension) => fileExtension.Equals(".pdf", StringComparison.OrdinalIgnoreCase);
 
-        public async Task<string> ReadFileContentAsync(string filePath)
+        public string ReadFileContent(string filePath)
         {
             var text = new StringBuilder();
 

--- a/Quizlet/Readers/PdfFileReader.cs
+++ b/Quizlet/Readers/PdfFileReader.cs
@@ -1,0 +1,22 @@
+﻿using Quizlet.Interfaces;
+using System.Text;
+using UglyToad.PdfPig;
+
+namespace Quizlet.Readers
+{
+    public class PdfFileReader : IFileReaderStrategy
+    {
+        public bool CanHandle(string fileExtension) => fileExtension.Equals(".pdf", StringComparison.OrdinalIgnoreCase);
+
+        public async Task<string> ReadFileContentAsync(string filePath)
+        {
+            var text = new StringBuilder();
+
+            using var stream = File.OpenRead(filePath);
+            using var document = PdfDocument.Open(stream);
+            foreach (var page in document.GetPages()) text.Append(string.Join(" ", page.GetWords()));
+
+            return text.ToString();
+        }
+    }
+}

--- a/Quizlet/Readers/TxtFileReader.cs
+++ b/Quizlet/Readers/TxtFileReader.cs
@@ -6,9 +6,9 @@ namespace Quizlet.Readers
     {
         public bool CanHandle(string fileExtension) => fileExtension.Equals(".txt", StringComparison.OrdinalIgnoreCase);
 
-        public async Task<string> ReadFileContentAsync(string filePath)
+        public string ReadFileContent(string filePath)
         {
-            return await File.ReadAllTextAsync(filePath);
+            return File.ReadAllText(filePath);
         }
     }
 }

--- a/Quizlet/Readers/TxtFileReader.cs
+++ b/Quizlet/Readers/TxtFileReader.cs
@@ -1,0 +1,14 @@
+﻿using Quizlet.Interfaces;
+
+namespace Quizlet.Readers
+{
+    public class TxtFileReader : IFileReaderStrategy
+    {
+        public bool CanHandle(string fileExtension) => fileExtension.Equals(".txt", StringComparison.OrdinalIgnoreCase);
+
+        public async Task<string> ReadFileContentAsync(string filePath)
+        {
+            return await File.ReadAllTextAsync(filePath);
+        }
+    }
+}

--- a/Quizlet/Services/FileService.cs
+++ b/Quizlet/Services/FileService.cs
@@ -11,7 +11,7 @@ public class FileService : IFileService
         _fileReaderStrategies = fileReaderStrategies;
     }
 
-    public async Task<string> ReadFileContentAsync(string filePath)
+    public string ReadFileContent(string filePath)
     {
         if (string.IsNullOrEmpty(filePath))
             throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
@@ -25,6 +25,6 @@ public class FileService : IFileService
         if (strategy == null)
             throw new NotSupportedException($"Extension '{extension}' isn't supported.");
 
-        return await strategy.ReadFileContentAsync(filePath);
+        return strategy.ReadFileContent(filePath);
     }
 }

--- a/Quizlet/Services/FileService.cs
+++ b/Quizlet/Services/FileService.cs
@@ -1,13 +1,16 @@
-using System.Text;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 using Quizlet.Interfaces;
-using UglyToad.PdfPig;
 
 namespace Quizlet.Services;
 
 public class FileService : IFileService
 {
+    private readonly IEnumerable<IFileReaderStrategy> _fileReaderStrategies;
+
+    public FileService(IEnumerable<IFileReaderStrategy> fileReaderStrategies)
+    {
+        _fileReaderStrategies = fileReaderStrategies;
+    }
+
     public async Task<string> ReadFileContentAsync(string filePath)
     {
         if (string.IsNullOrEmpty(filePath))
@@ -17,39 +20,11 @@ public class FileService : IFileService
             throw new FileNotFoundException("File not found.", filePath);
 
         var extension = Path.GetExtension(filePath).ToLower();
+        var strategy = _fileReaderStrategies.FirstOrDefault(s => s.CanHandle(extension));
 
-        return extension switch
-        {
-            ".txt" => await ReadTxtFileAsync(filePath),
-            ".pdf" => ReadPdfFile(filePath),
-            ".docx" => ReadDocxFile(filePath),
-            _ => throw new NotSupportedException("File type not supported.")
-        };
-    }
+        if (strategy == null)
+            throw new NotSupportedException($"Extension '{extension}' isn't supported.");
 
-    private static async Task<string> ReadTxtFileAsync(string filePath)
-    {
-        return await File.ReadAllTextAsync(filePath);
-    }
-
-    private static string ReadPdfFile(string filePath)
-    {
-        var text = new StringBuilder();
-
-        using var stream = File.OpenRead(filePath);
-        using var document = PdfDocument.Open(stream);
-        foreach (var page in document.GetPages()) text.Append(string.Join(" ", page.GetWords()));
-
-        return text.ToString();
-    }
-
-    private static string ReadDocxFile(string filePath)
-    {
-        using var doc = WordprocessingDocument.Open(filePath, false);
-        if (doc.MainDocumentPart?.Document?.Body == null)
-            throw new InvalidOperationException("The document structure is invalid or missing.");
-
-        return string.Join(Environment.NewLine, doc.MainDocumentPart.Document.Body.Elements<Paragraph>()
-            .Select(p => p.InnerText));
+        return await strategy.ReadFileContentAsync(filePath);
     }
 }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1,0 +1,52 @@
+# ADR 001: Verwendung des Strategy Pattern zum Lesen verschiedener Dateitypen
+
+**Status:** Vorgeschlagen
+
+---
+
+## Kontext
+
+Im Fileservice werden Inhalte aus verschiedenen Dateitypen wie `.txt`, `.pdf` und `.docx` gelesen. Die Art, wie Inhalte aus diesen Formaten ausgelesen werden, unterscheidet sich aufgrund unterschiedlicher Bibliotheken und Verarbeitungslogik.  
+Es war notwendig, diese Unterschiede zu kapseln, um die Wartbarkeit, Erweiterbarkeit und Testbarkeit der Anwendung zu verbessern.
+
+---
+
+## Entscheidung
+
+Wir haben uns entschieden, das **Strategy Pattern** zur Implementierung des Dateilesens zu verwenden.  
+Dazu wurde eine Schnittstelle `IFileReaderStrategy` definiert, welche die Methode `string ReadFileContent(string filePath)` bereitstellt. Für jeden unterstützten Dateityp gibt es eine eigene Implementierung:
+
+- `TxtFileReader` für `.txt`
+- `PdfFileReader` für `.pdf`
+- `DocxFileReader` für `.docx`
+
+Der `FileService` erhält zur Laufzeit alle registrierten Strategien per Dependency Injection und wählt anhand der Dateierweiterung zur Ausführungszeit die passende aus.
+
+---
+
+## Gründe für diese Entscheidung
+
+- **Offen für Erweiterung, geschlossen für Modifikation (Open/Closed Principle)**: Neue Dateiformate können einfach durch zusätzliche Strategien ergänzt werden, ohne bestehende Logik im `FileService` zu verändern.
+- **Saubere Trennung von Verantwortlichkeiten**: Jede Lesestrategie ist nur für ein Format zuständig, wodurch der Code verständlich und wartbar bleibt.
+- **Testbarkeit**: Strategien lassen sich einzeln testen oder durch Mocks im `FileService` ersetzen.
+- **Flexibilität durch DI**: Die lose Kopplung ermöglicht einfache Integration weiterer Dateitypen ohne Eingriff in die zentrale Geschäftslogik.
+
+---
+
+## Alternativen
+
+- **Direkte Formatbehandlung im `FileService`**  
+  _Nachteile_: schwer testbar, schlecht wartbar, verletzt SRP (Single Responsibility Principle).
+
+- **Factory Pattern statt Strategy Pattern**  
+  _Nachteil_: Die Factory wäre hier unnötig, da keine komplexe Initialisierung erforderlich ist und die Strategien direkt aufgerufen werden können.
+
+---
+
+## Konsequenzen
+
+- Zusätzlicher Initialaufwand bei der Einführung des Patterns (Schnittstelle + konkrete Klassen).
+- Alle unterstützten Formate müssen manuell als Strategien registriert werden.
+- Das DI-System (z. B. `Microsoft.Extensions.DependencyInjection`) muss korrekt konfiguriert sein, damit alle Strategien verfügbar sind.
+
+---


### PR DESCRIPTION
Refactors file reading mechanism by introducing Strategy Pattern. 

- Defined an `IFileReaderStrategy` interface with a method `ReadFileContentAsync(string filePath)`.
- Implemented the interface in `TxtFileReader`, `DocxFileReader`, and `PdfFileReader` classes, each handling their respective file formats.
- Refactored the `FileService` class to utilize the appropriate strategy based on the file extension.

